### PR TITLE
chore(deps): upgrade flysystem and illuminate dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,12 @@
     "require": {
         "php": ">=8.0",
         "aws/aws-sdk-php": "^3.189.0",
-        "league/flysystem": "^1.1",
-        "illuminate/container": "^v8.0.0",
-        "illuminate/contracts": "^v8.0.0",
-        "illuminate/filesystem": "^v8.0.0",
-        "illuminate/queue": "^v8.0.0",
-        "illuminate/support": "^v8.0.0"
+        "league/flysystem": "^3.0",
+        "illuminate/container": "^9.0.0",
+        "illuminate/contracts": "^9.0.0",
+        "illuminate/filesystem": "^9.0.0",
+        "illuminate/queue": "^9.0.0",
+        "illuminate/support": "^9.0.0"
     },
     "require-dev": {
         "mockery/mockery": "~1",


### PR DESCRIPTION
Hi there,

Thank you for this great package. 

This PR upgrades the dependencies to be compatible with Laravel 9. It is obviously a breaking change, so it will require a major version jump, unless you want to keep both versions in the composer file. Let me know if that's the case, and I'll update accordingly.

Tests are still passing ✅ 